### PR TITLE
fix: Add environment to update/restart

### DIFF
--- a/.github/workflows/restart.yaml
+++ b/.github/workflows/restart.yaml
@@ -10,8 +10,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
     name: "Restart ${{ inputs.environment }}"
+    environment:
+      name: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,8 +13,10 @@ on:
 
 jobs:
   deploy:
+    name: "Update dependencies of ${{ inputs.environment }}"
+    environment:
+      name: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    name: "Upgrade dependencies"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Fixes #6
- Add environment to update/restart scripts
- The secrets are otherwise not available during run

@charles-cooper this is not a great solution, as Github will mark all builds as "deployments".
It would be better to have the secrets available without the environment, too.