### PR TITLE
fix: Remove update `environment` input

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -4,18 +4,11 @@ on:
   schedule:
     # Run Monday at 4:00 UTC
     - cron: "0 4 * * 1"
-  workflow_dispatch:
-    inputs:
-     environment:
-        type: environment
-        description: Select the environment
-        default: stable
 
 jobs:
   deploy:
-    name: "Update dependencies of ${{ inputs.environment }}"
-    environment:
-      name: ${{ inputs.environment }}
+    name: "Update dependencies"
+    environment: stable
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- The default was not working when running with cron
- We only have one env currently, so we can hardcode it