### PR TITLE
Add memory limit to containers

### DIFF
--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -89,8 +89,7 @@ c.DockerSpawner.remove = True
 c.DockerSpawner.debug = True
 
 c.DockerSpawner.cpu_limit = 1
-# for some reason, enabling mem limit makes spawned containers not work
-#c.DockerSpawner.mem_limit = "512"
+c.DockerSpawner.mem_limit = lambda s: '8M' if s.user.name in c.GitHubOAuthenticator.blocked_users else "2G"
 
 # User containers will access hub by container name on the Docker network
 c.JupyterHub.hub_ip = "0.0.0.0"


### PR DESCRIPTION
Add a memory limit of 2GB for allowed users and 8MB for blocked users.

Jupyter does not force reauthentication when the user is blocked. So, existing sessions remain valid.

With this PR, if the user is blocked, the container fail when trying to start-up.

Fixes #9